### PR TITLE
Added logging, debug, and option to force this/next rotation generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         PERF_TRIAGE_BOT_CACHED_USER_SECRETS: ${{ secrets.PERF_TRIAGE_BOT_CACHED_USER_SECRETS }}
       run: |
-        python rotation.py --production
+        python rotation.py --production --debug
 
     - name: Push results
       run: |


### PR DESCRIPTION
I wanted to debug why a new member of the rotation hasn't been selected. It looks like it might be the luck of `shuffle`. Maybe we should make this a little less random? Anyway, this additional logging should help us to confirm when the next rotation is generated.